### PR TITLE
Fix scramble display for Megaminx, Square-1, and Skewb

### DIFF
--- a/CompSim/Scramblers/Megaminx.m
+++ b/CompSim/Scramblers/Megaminx.m
@@ -61,14 +61,14 @@ int seq[80];
             }
         }
         if (seq[(j+1)*linelen - 1]!=0) {
-            [s appendString:@"U  "]; // new line removed
+            [s appendString:@"U "]; // new line removed
             //state = applyMove(state, permU);
         }
         else {
-            [s appendString:@"U'  "]; // new line removed
+            [s appendString:@"U' "]; // new line removed
             //state = applyMove(state, permUi);
         }
     }
-    return s;
+    return [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 @end

--- a/CompSim/Scramblers/Skewb.m
+++ b/CompSim/Scramblers/Skewb.m
@@ -182,7 +182,7 @@ bool ini = false;
             for(int i=1; i<=depth; i++) {
                 [s appendFormat:@"%@%@ ", [turnSkb objectAtIndex:(solSkb[i]>>1)], [sufSkb objectAtIndex:(solSkb[i]&1)]];
             }
-            return s;
+            return [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         }
     }
     return @"";

--- a/CompSim/Scramblers/Sq1.m
+++ b/CompSim/Scramblers/Sq1.m
@@ -86,11 +86,11 @@
         if([[[seq objectAtIndex:i] objectAtIndex:0] intValue] == 7) {
             [s appendString:@"/ "];
         } else {
-            [s appendFormat:@"(%d,%d) ", [[[seq objectAtIndex:i] objectAtIndex:0] intValue], [[[seq objectAtIndex:i] objectAtIndex:1] intValue]];
+            [s appendFormat:@"(%d, %d) ", [[[seq objectAtIndex:i] objectAtIndex:0] intValue], [[[seq objectAtIndex:i] objectAtIndex:1] intValue]];
             //s.append("(" + seq[0][i][0] + "," + seq[0][i][1] + ") ");
         }
     }
-    return s;
+    return [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 
 - (NSString *) ssq1t_scramble {


### PR DESCRIPTION
This should fix the displayed scrambles by modifying whitespace in the scrambles.